### PR TITLE
disable error insert `⏎`

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ module.exports = {
         allowTypedFunctionExpressions: true
       }
     ],
-    '@typescript-eslint/indent': ['error', 2],
+    '@typescript-eslint/indent': 'off',
     '@typescript-eslint/member-delimiter-style': [
       'error',
       {
@@ -54,13 +54,7 @@ module.exports = {
         }
       }
     ],
-    '@typescript-eslint/prefer-interface': 0,
-    'prettier/prettier': [
-      'error',
-      {
-        endOfLine: 'auto'
-      }
-    ]
+    '@typescript-eslint/prefer-interface': 0
   },
   overrides: [
     {


### PR DESCRIPTION
Refer to Catal/Nozomi#4397 (comment)
~~prettierとtypescript-eslint/indentはコンフリクトになってるので、Disable error Insert ⏎をオフにします~~
prettierもindentサポートされてるので、@typescript-eslint/indent': 'off',を処理します